### PR TITLE
📝 Add docstrings to `home_dev`

### DIFF
--- a/src/main/java/com/example/demo/mapper/HomeMapper.java
+++ b/src/main/java/com/example/demo/mapper/HomeMapper.java
@@ -6,6 +6,13 @@ import org.apache.ibatis.annotations.Select;
 @Mapper
 public interface HomeMapper {
     
+    /**
+     * Counts models whose latest data log reports a temperature above 70 for AGV equipment (equipment_id = 1).
+     *
+     * The query considers only the most recent data_log per model_infos_id and returns the count as a Long (0 if none).
+     *
+     * @return the number of model_infos with latest data_log.temp > 70 for AGV equipment
+     */
     @Select("SELECT COUNT(dl.model_infos_id) " +
             "FROM model_infos mi " +
             "JOIN models m ON mi.model_id = m.model_id " +
@@ -16,6 +23,14 @@ public interface HomeMapper {
             "WHERE dl.temp > 70 AND m.equipment_id = 1")
     Long getAgvBatteryWrong();
 
+    /**
+     * Counts models (by model_infos_id) whose latest data_log shows temperature > 70 for robot arms.
+     *
+     * Computes the number of distinct model_infos entries whose most recent data_logs (by timestamp)
+     * have temp > 70 and whose associated model has equipment_id = 3. Returns 0 if none match.
+     *
+     * @return the count of model_infos with a latest data_log temperature over 70 for robot arm equipment
+     */
     @Select("SELECT COUNT(dl.model_infos_id) " +
             "FROM model_infos mi " +
             "JOIN models m ON mi.model_id = m.model_id " +
@@ -26,6 +41,13 @@ public interface HomeMapper {
             "WHERE dl.temp > 70 AND m.equipment_id = 3")
     Long getRobotArmBatteryWrong();
 
+    /**
+     * Counts models of equipment type 2 whose latest data_log records have temperature > 70.
+     *
+     * The count is computed per model_infos entry using only the most recent data_log for each model_infos_id.
+     *
+     * @return the number of model_infos whose latest data_log temperature exceeds 70 (may be zero)
+     */
     @Select("SELECT COUNT(dl.model_infos_id) " +
             "FROM model_infos mi " +
             "JOIN models m ON mi.model_id = m.model_id " +
@@ -36,6 +58,14 @@ public interface HomeMapper {
             "WHERE dl.temp > 70 AND m.equipment_id = 2")
     Long getLiftCarBatteryWrong();
 
+    /**
+     * Counts models (based on the latest data_log per model_infos record) for equipment type 4 where the latest temperature exceeds 70.
+     *
+     * The query considers only the most recent data_log for each model_infos_id and returns the number of those records
+     * whose `temp` > 70 for models with `equipment_id = 4`. Returns 0 when no matching records are found.
+     *
+     * @return the count of model_infos whose latest data_log has temp > 70 for equipment type 4
+     */
     @Select("SELECT COUNT(dl.model_infos_id) " +
             "FROM model_infos mi " +
             "JOIN models m ON mi.model_id = m.model_id " +


### PR DESCRIPTION
Docstrings generation was requested by @asho227.

* https://github.com/Hyundai-Autoever-Smart-Factory-2nd/battery3080-backend/pull/10#issuecomment-3231989417

The following files were modified:

* `src/main/java/com/example/demo/mapper/HomeMapper.java`

# PR 제목

## 변경 사항

-   무엇이 변경되었는지 간단히 설명해주세요.

## 관련 이슈

-   관련된 이슈 번호를 명시해주세요. (예: #123)

## 체크리스트

-   [ ] 코드에 오류가 없는지 확인
-   [ ] 문서화가 필요한 경우 문서 작성
-   [ ] 테스트가 필요한 경우 테스트 추가

## 기타

-   추가적으로 논의할 사항이나 참고할 내용이 있다면 작성해주세요.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- 문서화
  - 장비별 배터리 온도 이상(70℃ 초과) 건수 집계 로직에 대한 Javadoc을 기존 메서드에 추가했습니다.
  - 최신 로그 기준으로 집계함을 명시하고, 해당 데이터가 없을 경우 0을 반환한다는 규칙을 명확화했습니다.
  - 비즈니스 규칙과 반환 값 정의를 통일해 오해를 방지하고, 동작 이해도와 유지보수성을 향상했습니다.
  - 기능 동작이나 인터페이스의 변화는 없습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->